### PR TITLE
Add checkout page with order summary and styling

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -1,0 +1,631 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Checkout - Bread N' Brew</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Inter:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="bg-gray-50 text-gray-900">
+    <!-- Top Bar with Hours and Contact -->
+    <div class="bg-amber-700 text-white py-2 text-sm sticky top-0 z-50">
+      <div class="max-w-7xl mx-auto px-6 flex justify-between items-center">
+        <div class="flex items-center space-x-6">
+          <span class="font-medium"
+            >Hours: Mon-Sat 7am-5:30pm | Sun 9am-4pm</span
+          >
+        </div>
+        <div class="flex items-center space-x-6">
+          <a
+            href="tel:908-933-0123"
+            class="hover:text-gray-300 transition flex items-center"
+          >
+            <i data-lucide="phone" class="w-4 h-4 mr-2"></i>
+            (908) 933-0123
+          </a>
+          <a
+            href="https://www.google.com/maps/place/512+Springfield+Ave,+Berkeley+Heights,+NJ+07922"
+            target="_blank"
+            class="hover:text-gray-300 transition flex items-center"
+          >
+            <i data-lucide="map-pin" class="w-4 h-4 mr-2"></i>
+            512 Springfield Ave, Berkeley Heights, NJ
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <!-- Header & Navigation -->
+    <header
+      id="header"
+      class="bg-white shadow-md sticky top-8 z-40 transition-all duration-300"
+    >
+      <nav
+        class="max-w-7xl mx-auto px-6 py-6 flex justify-between items-center"
+      >
+        <a
+          href="index.html"
+          class="text-3xl font-bold text-pink-500 font-display"
+        >
+          <div>
+            Bread N' Br☕︎w
+            <span class="block text-xs font-normal text-gray-600 tracking-wider"
+              >Artisan Breads, Perfect Brews, & Fine Patisseries</span
+            >
+          </div>
+        </a>
+        <div class="hidden md:flex items-center space-x-8">
+          <a
+            href="index.html"
+            class="text-gray-700 hover:text-forest-green transition text-lg font-medium"
+            >Home</a
+          >
+          <a
+            href="menu.html"
+            class="text-gray-700 hover:text-forest-green transition text-lg font-medium"
+            >Menu</a
+          >
+          <a
+            href="index.html#catering"
+            class="text-gray-700 hover:text-forest-green transition text-lg font-medium"
+            >Catering</a
+          >
+          <a
+            href="index.html#about"
+            class="text-gray-700 hover:text-forest-green transition text-lg font-medium"
+            >About</a
+          >
+          <a
+            href="contact.html"
+            class="text-gray-700 hover:text-forest-green transition text-lg font-medium"
+            >Contact</a
+          >
+          <button
+            id="header-cart-btn"
+            class="hidden md:flex items-center gap-2 text-gray-700 hover:text-forest-green transition text-lg touch-target"
+          >
+            <i data-lucide="shopping-bag" class="w-5 h-5"></i>
+            <span>Cart</span>
+            <span
+              id="header-cart-count"
+              class="bg-forest-green text-white text-xs rounded-full h-5 w-5 flex items-center justify-center font-bold"
+              >0</span
+            >
+          </button>
+        </div>
+        <button
+          id="mobile-menu-button"
+          class="md:hidden touch-target flex items-center justify-center"
+        >
+          <i data-lucide="menu" class="w-6 h-6"></i>
+        </button>
+      </nav>
+      <!-- Mobile Menu -->
+      <div
+        id="mobile-menu"
+        class="mobile-menu-transition mobile-menu-hidden md:hidden bg-white border-t border-gray-100"
+      >
+        <div class="px-6 pb-6 space-y-3">
+          <a
+            href="index.html"
+            class="block py-3 text-gray-700 hover:text-forest-green text-lg touch-target font-medium"
+            >Home</a
+          >
+          <a
+            href="menu.html"
+            class="block py-3 text-gray-700 hover:text-forest-green text-lg touch-target font-medium"
+            >Menu</a
+          >
+          <a
+            href="index.html#catering"
+            class="block py-3 text-gray-700 hover:text-forest-green text-lg touch-target font-medium"
+            >Catering</a
+          >
+          <a
+            href="index.html#about"
+            class="block py-3 text-gray-700 hover:text-forest-green text-lg touch-target font-medium"
+            >About</a
+          >
+          <a
+            href="contact.html"
+            class="block py-3 text-gray-700 hover:text-forest-green text-lg touch-target font-medium"
+            >Contact</a
+          >
+          <button
+            id="mobile-cart-btn"
+            class="flex items-center justify-center gap-2 w-full py-3 text-gray-700 hover:text-forest-green text-lg touch-target font-medium"
+          >
+            <i data-lucide="shopping-bag" class="w-5 h-5"></i>
+            <span>Cart</span>
+            <span
+              id="mobile-cart-count"
+              class="bg-forest-green text-white text-xs rounded-full h-5 w-5 flex items-center justify-center font-bold"
+              >0</span
+            >
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-7xl mx-auto px-6 py-8">
+      <!-- Checkout Section -->
+      <div class="text-center mb-8">
+        <h1
+          class="text-4xl sm:text-5xl font-display font-bold text-gray-900 mb-4"
+        >
+          Checkout
+        </h1>
+        <div class="w-24 h-0.5 bg-amber-700 mx-auto mb-6"></div>
+        <p class="text-lg text-gray-600">
+          Review your order and complete your pickup details
+        </p>
+      </div>
+
+      <div class="grid lg:grid-cols-2 gap-8">
+        <!-- Order Summary -->
+        <div class="order-2 lg:order-1">
+          <div class="bg-white rounded-xl shadow-lg p-6 mb-6">
+            <h2 class="text-2xl font-bold text-gray-900 mb-4">Order Summary</h2>
+            <div id="checkout-cart-items" class="space-y-4 mb-6">
+              <!-- Cart items will be populated here -->
+            </div>
+            <div class="border-t pt-4 space-y-2">
+              <div class="flex justify-between text-lg">
+                <span>Subtotal:</span>
+                <span id="checkout-subtotal">$0.00</span>
+              </div>
+              <div class="flex justify-between text-lg">
+                <span>Tax (6.625%):</span>
+                <span id="checkout-tax">$0.00</span>
+              </div>
+              <div class="flex justify-between text-xl font-bold border-t pt-2">
+                <span>Total:</span>
+                <span id="checkout-total" class="text-amber-700">$0.00</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Pickup Information -->
+          <div class="bg-blue-50 rounded-xl p-6">
+            <h3 class="text-lg font-bold text-blue-900 mb-3">
+              <i data-lucide="info" class="w-5 h-5 inline mr-2"></i>
+              Pickup Information
+            </h3>
+            <div class="space-y-2 text-blue-800">
+              <p>
+                <strong>Location:</strong> 512 Springfield Ave, Berkeley
+                Heights, NJ 07922
+              </p>
+              <p><strong>Phone:</strong> (908) 933-0123</p>
+              <p><strong>Payment:</strong> Pay in-store when you arrive</p>
+              <p>
+                <strong>Accepted:</strong> Cash, Card, and Contactless payments
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Customer Details Form -->
+        <div class="order-1 lg:order-2">
+          <div class="bg-white rounded-xl shadow-lg p-6">
+            <h2 class="text-2xl font-bold text-gray-900 mb-6">Your Details</h2>
+
+            <form id="checkout-form" class="space-y-6">
+              <div>
+                <label
+                  for="customer-name"
+                  class="block text-sm font-semibold text-gray-700 mb-2"
+                >
+                  Full Name *
+                </label>
+                <input
+                  type="text"
+                  id="customer-name"
+                  name="name"
+                  required
+                  class="w-full border-2 border-gray-200 rounded-lg px-4 py-3 focus:border-amber-700 focus:ring-2 focus:ring-amber-700 focus:ring-opacity-20 transition text-lg"
+                  placeholder="Enter your full name"
+                />
+              </div>
+
+              <div>
+                <label
+                  for="customer-phone"
+                  class="block text-sm font-semibold text-gray-700 mb-2"
+                >
+                  Phone Number *
+                </label>
+                <input
+                  type="tel"
+                  id="customer-phone"
+                  name="phone"
+                  required
+                  class="w-full border-2 border-gray-200 rounded-lg px-4 py-3 focus:border-amber-700 focus:ring-2 focus:ring-amber-700 focus:ring-opacity-20 transition text-lg"
+                  placeholder="(555) 123-4567"
+                />
+              </div>
+
+              <div>
+                <label
+                  for="customer-email"
+                  class="block text-sm font-semibold text-gray-700 mb-2"
+                >
+                  Email Address
+                </label>
+                <input
+                  type="email"
+                  id="customer-email"
+                  name="email"
+                  class="w-full border-2 border-gray-200 rounded-lg px-4 py-3 focus:border-amber-700 focus:ring-2 focus:ring-amber-700 focus:ring-opacity-20 transition text-lg"
+                  placeholder="your.email@example.com"
+                />
+              </div>
+
+              <div>
+                <label
+                  for="pickup-time"
+                  class="block text-sm font-semibold text-gray-700 mb-2"
+                >
+                  Preferred Pickup Time *
+                </label>
+                <select
+                  id="pickup-time"
+                  name="pickupTime"
+                  required
+                  class="w-full border-2 border-gray-200 rounded-lg px-4 py-3 focus:border-amber-700 focus:ring-2 focus:ring-amber-700 focus:ring-opacity-20 transition text-lg"
+                >
+                  <option value="">Select pickup time</option>
+                  <option value="asap">As soon as possible (15-20 min)</option>
+                  <option value="30min">30 minutes</option>
+                  <option value="45min">45 minutes</option>
+                  <option value="1hour">1 hour</option>
+                  <option value="1.5hours">1.5 hours</option>
+                  <option value="2hours">2 hours</option>
+                </select>
+              </div>
+
+              <div>
+                <label
+                  for="special-instructions"
+                  class="block text-sm font-semibold text-gray-700 mb-2"
+                >
+                  Special Instructions
+                </label>
+                <textarea
+                  id="special-instructions"
+                  name="instructions"
+                  rows="4"
+                  class="w-full border-2 border-gray-200 rounded-lg px-4 py-3 focus:border-amber-700 focus:ring-2 focus:ring-amber-700 focus:ring-opacity-20 transition text-lg resize-y"
+                  placeholder="Any special requests, dietary considerations, or pickup notes..."
+                ></textarea>
+              </div>
+
+              <div class="flex flex-col sm:flex-row gap-4 pt-6">
+                <button
+                  type="button"
+                  id="back-to-menu"
+                  class="flex-1 bg-gray-200 text-gray-800 font-semibold py-4 px-6 rounded-full hover:bg-gray-300 transition text-lg touch-target"
+                >
+                  Back to Menu
+                </button>
+                <button
+                  type="submit"
+                  id="place-order-btn"
+                  class="flex-1 bg-amber-700 text-white font-semibold py-4 px-6 rounded-full hover:bg-amber-800 transition text-lg touch-target"
+                >
+                  Place Order
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-gray-800 text-white py-16 mt-16">
+      <div class="max-w-7xl mx-auto px-6">
+        <div class="grid md:grid-cols-4 gap-8">
+          <div class="md:col-span-2">
+            <h3 class="text-2xl font-display font-bold text-pink-500 mb-4">
+              Bread N' Brew
+            </h3>
+            <p class="text-gray-300 leading-relaxed mb-6">
+              Your neighborhood destination for fresh-baked goods and expertly
+              crafted coffee. Made with care, served with pride.
+            </p>
+            <div class="flex space-x-4">
+              <a href="#" class="text-gray-400 hover:text-pink-400 transition">
+                <i data-lucide="instagram" class="w-6 h-6"></i>
+              </a>
+              <a href="#" class="text-gray-400 hover:text-pink-400 transition">
+                <i data-lucide="facebook" class="w-6 h-6"></i>
+              </a>
+              <a href="#" class="text-gray-400 hover:text-pink-400 transition">
+                <i data-lucide="twitter" class="w-6 h-6"></i>
+              </a>
+            </div>
+          </div>
+          <div>
+            <h4 class="text-lg font-semibold mb-4">Quick Links</h4>
+            <ul class="space-y-2">
+              <li>
+                <a
+                  href="index.html"
+                  class="text-gray-300 hover:text-pink-400 transition"
+                  >Home</a
+                >
+              </li>
+              <li>
+                <a
+                  href="menu.html"
+                  class="text-gray-300 hover:text-pink-400 transition"
+                  >Menu</a
+                >
+              </li>
+              <li>
+                <a
+                  href="index.html#catering"
+                  class="text-gray-300 hover:text-pink-400 transition"
+                  >Catering</a
+                >
+              </li>
+              <li>
+                <a
+                  href="index.html#about"
+                  class="text-gray-300 hover:text-pink-400 transition"
+                  >About</a
+                >
+              </li>
+              <li>
+                <a
+                  href="contact.html"
+                  class="text-gray-300 hover:text-pink-400 transition"
+                  >Contact</a
+                >
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h4 class="text-lg font-semibold mb-4">Contact</h4>
+            <ul class="space-y-2 text-gray-300">
+              <li>(908) 933-0123</li>
+              <li>breadnbrew512@gmail.com</li>
+              <li>512 Springfield Ave<br />Berkeley Heights, NJ</li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="border-t border-gray-700 mt-12 pt-8 text-center text-gray-400"
+        >
+          <p>&copy; 2025 Bread N' Brew. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+
+    <!-- Floating Cart Button -->
+    <button
+      id="floating-cart-btn"
+      class="floating-cart-btn fixed bottom-6 right-6 bg-forest-green text-white w-16 h-16 rounded-full shadow-lg flex items-center justify-center z-40 touch-target hover:bg-forest-green-dark transition transform hover:scale-110"
+    >
+      <i data-lucide="shopping-bag" class="w-7 h-7"></i>
+      <span
+        id="cart-item-count"
+        class="absolute -top-2 -right-2 bg-pink-500 text-white text-xs rounded-full h-6 w-6 flex items-center justify-center font-bold"
+        >0</span
+      >
+    </button>
+
+    <!-- Cart Backdrop -->
+    <div id="cart-backdrop" class="cart-backdrop"></div>
+
+    <!-- Shopping Cart -->
+    <div
+      id="cart"
+      class="cart cart-hidden fixed right-0 top-0 h-full w-full sm:max-w-md bg-white shadow-2xl flex flex-col"
+    >
+      <!-- Cart will be rendered here by JS -->
+    </div>
+
+    <!-- Toast Notification -->
+    <div
+      id="toast-wrapper"
+      class="toast-wrapper fixed bottom-24 left-4 right-4 sm:left-0 sm:right-0 text-center z-50"
+    >
+      <div
+        id="toast-message"
+        class="inline-block bg-gray-900 text-white py-3 px-6 rounded-full shadow-lg"
+      >
+        Item added to your cart!
+      </div>
+    </div>
+
+    <!-- Custom Modal -->
+    <div
+      id="custom-modal"
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 hidden p-4"
+    >
+      <div
+        class="bg-white p-8 rounded-xl shadow-lg text-center max-w-sm mx-auto w-full"
+      >
+        <div id="modal-content">
+          <h3
+            id="modal-title"
+            class="text-xl sm:text-2xl font-display font-bold mb-4 text-gray-900"
+          >
+            Notice
+          </h3>
+          <div id="modal-body" class="text-gray-600 mb-6">Message here.</div>
+          <div id="modal-actions">
+            <button
+              class="modal-close-btn bg-forest-green text-white font-semibold py-3 px-8 rounded-full touch-target hover:bg-forest-green-dark transition"
+            >
+              OK
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="data.js"></script>
+    <script src="script.js"></script>
+    <script>
+      // Checkout page specific functionality
+      document.addEventListener("DOMContentLoaded", function () {
+        loadCheckoutData();
+
+        // Handle back to menu button
+        document
+          .getElementById("back-to-menu")
+          .addEventListener("click", () => {
+            window.location.href = "menu.html";
+          });
+
+        // Handle form submission
+        document
+          .getElementById("checkout-form")
+          .addEventListener("submit", (e) => {
+            e.preventDefault();
+            submitOrder();
+          });
+      });
+
+      function loadCheckoutData() {
+        // Get cart data from localStorage
+        const savedCartItems = localStorage.getItem("cartItems");
+        if (!savedCartItems) {
+          // No cart data, redirect to menu
+          window.location.href = "menu.html";
+          return;
+        }
+
+        const cartItems = JSON.parse(savedCartItems);
+        if (cartItems.length === 0) {
+          window.location.href = "menu.html";
+          return;
+        }
+
+        // Display cart items
+        const cartContainer = document.getElementById("checkout-cart-items");
+        cartContainer.innerHTML = cartItems
+          .map(
+            (item) => `
+          <div class="flex gap-3 py-3 border-b border-gray-100 last:border-b-0">
+            <img src="${item.img}" alt="${item.name}" class="w-16 h-16 object-cover rounded-lg flex-shrink-0">
+            <div class="flex-1">
+              <div class="flex justify-between items-start mb-1">
+                <h4 class="font-semibold text-gray-900">${item.name}</h4>
+                <span class="text-amber-700 font-bold">$${(item.price * item.quantity).toFixed(2)}</span>
+              </div>
+              <p class="text-sm text-gray-600 mb-2">Qty: ${item.quantity}</p>
+              ${
+                item.customizations &&
+                Object.keys(item.customizations).length > 0
+                  ? `
+                <div class="text-xs text-gray-500">
+                  ${Object.entries(item.customizations)
+                    .map(([key, value]) => {
+                      if (
+                        key === "toppings" &&
+                        Array.isArray(value) &&
+                        value.length > 0
+                      ) {
+                        return `Toppings: ${value.join(", ")}`;
+                      } else if (key === "test" && value) {
+                        return `${key}: ${value}`;
+                      }
+                      return "";
+                    })
+                    .filter(Boolean)
+                    .join(" • ")}
+                </div>
+              `
+                  : ""
+              }
+            </div>
+          </div>
+        `,
+          )
+          .join("");
+
+        // Calculate totals
+        const subtotal = cartItems.reduce(
+          (sum, item) => sum + item.price * item.quantity,
+          0,
+        );
+        const tax = subtotal * 0.06625;
+        const total = subtotal + tax;
+
+        document.getElementById("checkout-subtotal").textContent =
+          `$${subtotal.toFixed(2)}`;
+        document.getElementById("checkout-tax").textContent =
+          `$${tax.toFixed(2)}`;
+        document.getElementById("checkout-total").textContent =
+          `$${total.toFixed(2)}`;
+      }
+
+      function submitOrder() {
+        const form = document.getElementById("checkout-form");
+        const formData = new FormData(form);
+
+        const savedCartItems = localStorage.getItem("cartItems");
+        const cartItems = JSON.parse(savedCartItems || "[]");
+
+        const orderData = {
+          name: formData.get("name"),
+          phone: formData.get("phone"),
+          email: formData.get("email"),
+          pickupTime: formData.get("pickupTime"),
+          instructions: formData.get("instructions"),
+          items: cartItems,
+          timestamp: new Date().toLocaleString(),
+          total:
+            cartItems.reduce(
+              (sum, item) => sum + item.price * item.quantity,
+              0,
+            ) * 1.06625,
+        };
+
+        console.log("Order submitted:", orderData);
+
+        // Clear cart from localStorage
+        localStorage.removeItem("cartItems");
+
+        // Show success and redirect
+        showModal(
+          "Order Confirmed!",
+          `<div class="text-center">
+            <div class="text-green-600 mb-4">
+              <i data-lucide="check-circle" class="w-16 h-16 mx-auto mb-2"></i>
+            </div>
+            <p class="mb-4">Thank you <strong>${orderData.name}</strong>! Your order has been received.</p>
+            <p class="text-sm text-gray-600 mb-4">We'll call you at <strong>${orderData.phone}</strong> when your order is ready for pickup.</p>
+            <div class="bg-amber-50 p-3 rounded-lg text-sm">
+              <strong>Estimated pickup time:</strong> ${orderData.pickupTime === "asap" ? "15-20 minutes" : orderData.pickupTime}
+            </div>
+          </div>`,
+          '<div class="flex justify-center"><button id="order-complete-btn" class="bg-amber-700 text-white font-semibold py-3 px-8 rounded-full touch-target hover:bg-amber-800 transition">Continue</button></div>',
+        );
+
+        if (typeof lucide !== "undefined") {
+          lucide.createIcons();
+        }
+
+        // Handle redirect after confirmation
+        document.addEventListener("click", (e) => {
+          if (e.target.id === "order-complete-btn") {
+            window.location.href = "index.html";
+          }
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/checkout.html
+++ b/checkout.html
@@ -177,10 +177,79 @@
             <div id="checkout-cart-items" class="space-y-4 mb-6">
               <!-- Cart items will be populated here -->
             </div>
+            <!-- Tipping Section -->
+            <div class="border-t pt-4 mb-4">
+              <h3 class="text-lg font-semibold text-gray-900 mb-3">
+                <i
+                  data-lucide="heart"
+                  class="w-5 h-5 inline mr-2 text-pink-500"
+                ></i>
+                Add a Tip for Our Team
+              </h3>
+              <div class="grid grid-cols-4 gap-2 mb-3">
+                <button
+                  type="button"
+                  class="tip-btn bg-white border-2 border-gray-200 text-gray-700 py-2 px-3 rounded-lg font-semibold hover:border-amber-700 hover:text-amber-700 transition"
+                  data-tip="15"
+                >
+                  15%
+                </button>
+                <button
+                  type="button"
+                  class="tip-btn bg-white border-2 border-gray-200 text-gray-700 py-2 px-3 rounded-lg font-semibold hover:border-amber-700 hover:text-amber-700 transition"
+                  data-tip="18"
+                >
+                  18%
+                </button>
+                <button
+                  type="button"
+                  class="tip-btn bg-white border-2 border-gray-200 text-gray-700 py-2 px-3 rounded-lg font-semibold hover:border-amber-700 hover:text-amber-700 transition"
+                  data-tip="23"
+                >
+                  23%
+                </button>
+                <button
+                  type="button"
+                  class="tip-btn bg-white border-2 border-gray-200 text-gray-700 py-2 px-3 rounded-lg font-semibold hover:border-amber-700 hover:text-amber-700 transition"
+                  data-tip="custom"
+                >
+                  Custom
+                </button>
+              </div>
+              <div id="custom-tip-input" class="hidden mb-3">
+                <div class="flex items-center gap-2">
+                  <input
+                    type="number"
+                    id="custom-tip-percentage"
+                    placeholder="Enter %"
+                    min="0"
+                    max="50"
+                    class="flex-1 border-2 border-gray-200 rounded-lg px-3 py-2 focus:border-amber-700 focus:ring-2 focus:ring-amber-700 focus:ring-opacity-20 transition"
+                  />
+                  <span class="text-gray-600">%</span>
+                </div>
+              </div>
+              <button
+                type="button"
+                id="no-tip-btn"
+                class="text-sm text-gray-500 hover:text-gray-700 transition underline"
+              >
+                No tip
+              </button>
+            </div>
+
             <div class="border-t pt-4 space-y-2">
               <div class="flex justify-between text-lg">
                 <span>Subtotal:</span>
                 <span id="checkout-subtotal">$0.00</span>
+              </div>
+              <div
+                class="flex justify-between text-lg"
+                id="tip-row"
+                style="display: none"
+              >
+                <span>Tip (<span id="tip-percentage">0</span>%):</span>
+                <span id="checkout-tip">$0.00</span>
               </div>
               <div class="flex justify-between text-lg">
                 <span>Tax (6.625%):</span>
@@ -479,8 +548,12 @@
     <script src="script.js"></script>
     <script>
       // Checkout page specific functionality
+      let currentTipPercentage = 0;
+      let cartItemsData = [];
+
       document.addEventListener("DOMContentLoaded", function () {
         loadCheckoutData();
+        setupTipHandlers();
 
         // Handle back to menu button
         document
@@ -498,6 +571,106 @@
           });
       });
 
+      function setupTipHandlers() {
+        // Handle tip button clicks
+        document.querySelectorAll(".tip-btn").forEach((btn) => {
+          btn.addEventListener("click", (e) => {
+            const tipValue = e.target.dataset.tip;
+
+            // Remove selected class from all buttons
+            document.querySelectorAll(".tip-btn").forEach((b) => {
+              b.classList.remove(
+                "border-amber-700",
+                "text-amber-700",
+                "bg-amber-50",
+              );
+              b.classList.add("border-gray-200", "text-gray-700");
+            });
+
+            if (tipValue === "custom") {
+              // Show custom input
+              document
+                .getElementById("custom-tip-input")
+                .classList.remove("hidden");
+              e.target.classList.add(
+                "border-amber-700",
+                "text-amber-700",
+                "bg-amber-50",
+              );
+              document.getElementById("custom-tip-percentage").focus();
+            } else {
+              // Hide custom input and set tip percentage
+              document
+                .getElementById("custom-tip-input")
+                .classList.add("hidden");
+              currentTipPercentage = parseInt(tipValue);
+              e.target.classList.add(
+                "border-amber-700",
+                "text-amber-700",
+                "bg-amber-50",
+              );
+              updateTotals();
+            }
+          });
+        });
+
+        // Handle custom tip input
+        document
+          .getElementById("custom-tip-percentage")
+          .addEventListener("input", (e) => {
+            const value = parseFloat(e.target.value) || 0;
+            currentTipPercentage = Math.max(0, Math.min(50, value)); // Limit between 0-50%
+            updateTotals();
+          });
+
+        // Handle no tip button
+        document.getElementById("no-tip-btn").addEventListener("click", () => {
+          currentTipPercentage = 0;
+          document.getElementById("custom-tip-input").classList.add("hidden");
+          document.querySelectorAll(".tip-btn").forEach((b) => {
+            b.classList.remove(
+              "border-amber-700",
+              "text-amber-700",
+              "bg-amber-50",
+            );
+            b.classList.add("border-gray-200", "text-gray-700");
+          });
+          updateTotals();
+        });
+      }
+
+      function updateTotals() {
+        if (cartItemsData.length === 0) return;
+
+        const subtotal = cartItemsData.reduce(
+          (sum, item) => sum + item.price * item.quantity,
+          0,
+        );
+        const tipAmount = subtotal * (currentTipPercentage / 100);
+        const tax = (subtotal + tipAmount) * 0.06625;
+        const total = subtotal + tipAmount + tax;
+
+        document.getElementById("checkout-subtotal").textContent =
+          `$${subtotal.toFixed(2)}`;
+
+        // Show/hide tip row
+        const tipRow = document.getElementById("tip-row");
+        if (currentTipPercentage > 0) {
+          tipRow.style.display = "flex";
+          document.getElementById("tip-percentage").textContent =
+            currentTipPercentage.toFixed(0);
+          document.getElementById("checkout-tip").textContent =
+            `$${tipAmount.toFixed(2)}`;
+        } else {
+          tipRow.style.display = "none";
+        }
+
+        document.getElementById("checkout-tax").textContent =
+          `$${tax.toFixed(2)}`;
+        document.getElementById("checkout-total").textContent =
+          `$${total.toFixed(2)}`;
+      }
+
       function loadCheckoutData() {
         // Get cart data from localStorage
         const savedCartItems = localStorage.getItem("cartItems");
@@ -507,15 +680,15 @@
           return;
         }
 
-        const cartItems = JSON.parse(savedCartItems);
-        if (cartItems.length === 0) {
+        cartItemsData = JSON.parse(savedCartItems);
+        if (cartItemsData.length === 0) {
           window.location.href = "menu.html";
           return;
         }
 
         // Display cart items
         const cartContainer = document.getElementById("checkout-cart-items");
-        cartContainer.innerHTML = cartItems
+        cartContainer.innerHTML = cartItemsData
           .map(
             (item) => `
           <div class="flex gap-3 py-3 border-b border-gray-100 last:border-b-0">
@@ -556,28 +729,21 @@
           )
           .join("");
 
-        // Calculate totals
-        const subtotal = cartItems.reduce(
-          (sum, item) => sum + item.price * item.quantity,
-          0,
-        );
-        const tax = subtotal * 0.06625;
-        const total = subtotal + tax;
-
-        document.getElementById("checkout-subtotal").textContent =
-          `$${subtotal.toFixed(2)}`;
-        document.getElementById("checkout-tax").textContent =
-          `$${tax.toFixed(2)}`;
-        document.getElementById("checkout-total").textContent =
-          `$${total.toFixed(2)}`;
+        // Initial totals calculation (without tip)
+        updateTotals();
       }
 
       function submitOrder() {
         const form = document.getElementById("checkout-form");
         const formData = new FormData(form);
 
-        const savedCartItems = localStorage.getItem("cartItems");
-        const cartItems = JSON.parse(savedCartItems || "[]");
+        const subtotal = cartItemsData.reduce(
+          (sum, item) => sum + item.price * item.quantity,
+          0,
+        );
+        const tipAmount = subtotal * (currentTipPercentage / 100);
+        const tax = (subtotal + tipAmount) * 0.06625;
+        const total = subtotal + tipAmount + tax;
 
         const orderData = {
           name: formData.get("name"),
@@ -585,13 +751,18 @@
           email: formData.get("email"),
           pickupTime: formData.get("pickupTime"),
           instructions: formData.get("instructions"),
-          items: cartItems,
+          items: cartItemsData,
+          tip: {
+            percentage: currentTipPercentage,
+            amount: tipAmount,
+          },
+          pricing: {
+            subtotal: subtotal,
+            tip: tipAmount,
+            tax: tax,
+            total: total,
+          },
           timestamp: new Date().toLocaleString(),
-          total:
-            cartItems.reduce(
-              (sum, item) => sum + item.price * item.quantity,
-              0,
-            ) * 1.06625,
         };
 
         console.log("Order submitted:", orderData);

--- a/checkout.html
+++ b/checkout.html
@@ -377,20 +377,116 @@
                 ></textarea>
               </div>
 
-              <div class="flex flex-col sm:flex-row gap-4 pt-6">
-                <button
-                  type="button"
-                  id="back-to-menu"
-                  class="flex-1 bg-gray-200 text-gray-800 font-semibold py-4 px-6 rounded-full hover:bg-gray-300 transition text-lg touch-target"
-                >
-                  Back to Menu
-                </button>
+              <!-- Payment Methods Section -->
+              <div class="pt-6">
+                <h3 class="text-lg font-semibold text-gray-900 mb-4">
+                  <i
+                    data-lucide="credit-card"
+                    class="w-5 h-5 inline mr-2 text-amber-700"
+                  ></i>
+                  Choose Payment Method
+                </h3>
+                <div class="space-y-3 mb-6">
+                  <!-- Credit/Debit Card -->
+                  <button
+                    type="button"
+                    id="card-payment-btn"
+                    class="payment-method-btn w-full flex items-center justify-center gap-3 bg-white border-2 border-gray-200 text-gray-800 font-semibold py-4 px-6 rounded-xl hover:border-amber-700 hover:bg-amber-50 transition text-lg touch-target"
+                  >
+                    <i
+                      data-lucide="credit-card"
+                      class="w-6 h-6 text-amber-700"
+                    ></i>
+                    <span>Credit / Debit Card</span>
+                    <div class="flex gap-2 ml-auto">
+                      <div
+                        class="w-8 h-5 bg-blue-600 rounded text-white text-xs flex items-center justify-center font-bold"
+                      >
+                        VISA
+                      </div>
+                      <div
+                        class="w-8 h-5 bg-red-500 rounded text-white text-xs flex items-center justify-center font-bold"
+                      >
+                        MC
+                      </div>
+                      <div
+                        class="w-8 h-5 bg-blue-400 rounded text-white text-xs flex items-center justify-center font-bold"
+                      >
+                        AMEX
+                      </div>
+                    </div>
+                  </button>
+
+                  <!-- Apple Pay -->
+                  <button
+                    type="button"
+                    id="apple-pay-btn"
+                    class="payment-method-btn w-full flex items-center justify-center gap-3 bg-black text-white font-semibold py-4 px-6 rounded-xl hover:bg-gray-800 transition text-lg touch-target"
+                  >
+                    <svg
+                      class="w-6 h-6"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                    >
+                      <path
+                        d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                      />
+                    </svg>
+                    <span>Apple Pay</span>
+                  </button>
+
+                  <!-- Google Pay -->
+                  <button
+                    type="button"
+                    id="google-pay-btn"
+                    class="payment-method-btn w-full flex items-center justify-center gap-3 bg-white border-2 border-gray-200 text-gray-800 font-semibold py-4 px-6 rounded-xl hover:border-blue-500 hover:bg-blue-50 transition text-lg touch-target"
+                  >
+                    <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none">
+                      <path
+                        d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
+                        fill="#4285F4"
+                      />
+                      <path
+                        d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
+                        fill="#34A853"
+                      />
+                      <path
+                        d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
+                        fill="#FBBC05"
+                      />
+                      <path
+                        d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z"
+                        fill="#EA4335"
+                      />
+                    </svg>
+                    <span>Google Pay</span>
+                  </button>
+                </div>
+
+                <div class="text-center mb-4">
+                  <span
+                    class="text-sm text-gray-500 bg-gray-50 px-3 py-1 rounded-full"
+                    >OR</span
+                  >
+                </div>
+
+                <!-- Traditional Order Button -->
                 <button
                   type="submit"
                   id="place-order-btn"
-                  class="flex-1 bg-amber-700 text-white font-semibold py-4 px-6 rounded-full hover:bg-amber-800 transition text-lg touch-target"
+                  class="w-full bg-amber-700 text-white font-semibold py-4 px-6 rounded-xl hover:bg-amber-800 transition text-lg touch-target mb-4"
                 >
-                  Place Order
+                  <i data-lucide="shopping-bag" class="w-5 h-5 inline mr-2"></i>
+                  Place Order (Pay In-Store)
+                </button>
+
+                <button
+                  type="button"
+                  id="back-to-menu"
+                  class="w-full bg-gray-200 text-gray-800 font-semibold py-4 px-6 rounded-xl hover:bg-gray-300 transition text-lg touch-target"
+                >
+                  <i data-lucide="arrow-left" class="w-5 h-5 inline mr-2"></i>
+                  Back to Menu
                 </button>
               </div>
             </form>
@@ -570,6 +666,9 @@
             e.preventDefault();
             submitOrder();
           });
+
+        // Handle payment method buttons
+        setupPaymentHandlers();
       });
 
       function setDefaultTip() {
@@ -687,6 +786,82 @@
 
         document.getElementById("checkout-total").textContent =
           `$${total.toFixed(2)}`;
+      }
+
+      function setupPaymentHandlers() {
+        // Credit/Debit Card Payment
+        document
+          .getElementById("card-payment-btn")
+          .addEventListener("click", () => {
+            if (validateOrderDetails()) {
+              showModal(
+                "Card Payment",
+                `<div class="text-center">
+                <div class="text-blue-600 mb-4">
+                  <i data-lucide="credit-card" class="w-16 h-16 mx-auto mb-2"></i>
+                </div>
+                <p class="mb-4">Card payment processing is not yet available.</p>
+                <p class="text-sm text-gray-600">Please use "Place Order (Pay In-Store)" option to complete your order and pay when you pick up.</p>
+              </div>`,
+                '<div class="flex justify-center"><button class="modal-close-btn bg-blue-600 text-white font-semibold py-3 px-8 rounded-full touch-target hover:bg-blue-700 transition">OK</button></div>',
+              );
+              if (typeof lucide !== "undefined") {
+                lucide.createIcons();
+              }
+            }
+          });
+
+        // Apple Pay
+        document
+          .getElementById("apple-pay-btn")
+          .addEventListener("click", () => {
+            if (validateOrderDetails()) {
+              showModal(
+                "Apple Pay",
+                `<div class="text-center">
+                <div class="text-gray-800 mb-4">
+                  <svg class="w-16 h-16 mx-auto mb-2" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
+                  </svg>
+                </div>
+                <p class="mb-4">Apple Pay is not yet available.</p>
+                <p class="text-sm text-gray-600">Please use "Place Order (Pay In-Store)" option to complete your order and pay when you pick up.</p>
+              </div>`,
+                '<div class="flex justify-center"><button class="modal-close-btn bg-gray-800 text-white font-semibold py-3 px-8 rounded-full touch-target hover:bg-gray-700 transition">OK</button></div>',
+              );
+            }
+          });
+
+        // Google Pay
+        document
+          .getElementById("google-pay-btn")
+          .addEventListener("click", () => {
+            if (validateOrderDetails()) {
+              showModal(
+                "Google Pay",
+                `<div class="text-center">
+                <div class="text-blue-600 mb-4">
+                  <svg class="w-16 h-16 mx-auto mb-2" viewBox="0 0 24 24" fill="none">
+                    <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z" fill="#4285F4"/>
+                  </svg>
+                </div>
+                <p class="mb-4">Google Pay is not yet available.</p>
+                <p class="text-sm text-gray-600">Please use "Place Order (Pay In-Store)" option to complete your order and pay when you pick up.</p>
+              </div>`,
+                '<div class="flex justify-center"><button class="modal-close-btn bg-blue-600 text-white font-semibold py-3 px-8 rounded-full touch-target hover:bg-blue-700 transition">OK</button></div>',
+              );
+            }
+          });
+      }
+
+      function validateOrderDetails() {
+        const form = document.getElementById("checkout-form");
+        const isValid = form.checkValidity();
+        if (!isValid) {
+          form.reportValidity();
+          return false;
+        }
+        return true;
       }
 
       function loadCheckoutData() {

--- a/checkout.html
+++ b/checkout.html
@@ -243,6 +243,10 @@
                 <span>Subtotal:</span>
                 <span id="checkout-subtotal">$0.00</span>
               </div>
+              <div class="flex justify-between text-lg">
+                <span>Tax (6.625%):</span>
+                <span id="checkout-tax">$0.00</span>
+              </div>
               <div
                 class="flex justify-between text-lg"
                 id="tip-row"
@@ -250,10 +254,6 @@
               >
                 <span>Tip (<span id="tip-percentage">0</span>%):</span>
                 <span id="checkout-tip">$0.00</span>
-              </div>
-              <div class="flex justify-between text-lg">
-                <span>Tax (6.625%):</span>
-                <span id="checkout-tax">$0.00</span>
               </div>
               <div class="flex justify-between text-xl font-bold border-t pt-2">
                 <span>Total:</span>
@@ -664,12 +664,14 @@
           (sum, item) => sum + item.price * item.quantity,
           0,
         );
+        const tax = subtotal * 0.06625; // Tax only on subtotal, not tip
         const tipAmount = subtotal * (currentTipPercentage / 100);
-        const tax = (subtotal + tipAmount) * 0.06625;
-        const total = subtotal + tipAmount + tax;
+        const total = subtotal + tax + tipAmount;
 
         document.getElementById("checkout-subtotal").textContent =
           `$${subtotal.toFixed(2)}`;
+        document.getElementById("checkout-tax").textContent =
+          `$${tax.toFixed(2)}`;
 
         // Show/hide tip row
         const tipRow = document.getElementById("tip-row");
@@ -683,8 +685,6 @@
           tipRow.style.display = "none";
         }
 
-        document.getElementById("checkout-tax").textContent =
-          `$${tax.toFixed(2)}`;
         document.getElementById("checkout-total").textContent =
           `$${total.toFixed(2)}`;
       }
@@ -759,9 +759,9 @@
           (sum, item) => sum + item.price * item.quantity,
           0,
         );
+        const tax = subtotal * 0.06625; // Tax only on subtotal, not tip
         const tipAmount = subtotal * (currentTipPercentage / 100);
-        const tax = (subtotal + tipAmount) * 0.06625;
-        const total = subtotal + tipAmount + tax;
+        const total = subtotal + tax + tipAmount;
 
         const orderData = {
           name: formData.get("name"),

--- a/checkout.html
+++ b/checkout.html
@@ -548,12 +548,13 @@
     <script src="script.js"></script>
     <script>
       // Checkout page specific functionality
-      let currentTipPercentage = 0;
+      let currentTipPercentage = 18; // Default to 18%
       let cartItemsData = [];
 
       document.addEventListener("DOMContentLoaded", function () {
         loadCheckoutData();
         setupTipHandlers();
+        setDefaultTip(); // Set 18% as default
 
         // Handle back to menu button
         document
@@ -570,6 +571,23 @@
             submitOrder();
           });
       });
+
+      function setDefaultTip() {
+        // Find and auto-select the 18% button
+        const tip18Button = document.querySelector('[data-tip="18"]');
+        if (tip18Button) {
+          // Apply selected styling
+          tip18Button.classList.remove("border-gray-200", "text-gray-700");
+          tip18Button.classList.add(
+            "border-amber-700",
+            "text-amber-700",
+            "bg-amber-50",
+          );
+
+          // Update totals with default tip
+          updateTotals();
+        }
+      }
 
       function setupTipHandlers() {
         // Handle tip button clicks

--- a/contact.html
+++ b/contact.html
@@ -410,6 +410,46 @@
       <!-- Cart will be rendered here by JS -->
     </div>
 
+    <!-- Toast Notification -->
+    <div
+      id="toast-wrapper"
+      class="toast-wrapper fixed bottom-24 left-4 right-4 sm:left-0 sm:right-0 text-center z-50"
+    >
+      <div
+        id="toast-message"
+        class="inline-block bg-gray-900 text-white py-3 px-6 rounded-full shadow-lg"
+      >
+        Item added to your cart!
+      </div>
+    </div>
+
+    <!-- Custom Modal -->
+    <div
+      id="custom-modal"
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 hidden p-4"
+    >
+      <div
+        class="bg-white p-8 rounded-xl shadow-lg text-center max-w-sm mx-auto w-full"
+      >
+        <div id="modal-content">
+          <h3
+            id="modal-title"
+            class="text-xl sm:text-2xl font-display font-bold mb-4 text-gray-900"
+          >
+            Notice
+          </h3>
+          <div id="modal-body" class="text-gray-600 mb-6">Message here.</div>
+          <div id="modal-actions">
+            <button
+              class="modal-close-btn bg-forest-green text-white font-semibold py-3 px-8 rounded-full touch-target hover:bg-forest-green-dark transition"
+            >
+              OK
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script src="data.js"></script>
     <script src="script.js"></script>
     <script>

--- a/contact.html
+++ b/contact.html
@@ -392,7 +392,7 @@
     <!-- Shopping Cart -->
     <div
       id="cart"
-      class="cart cart-hidden fixed right-0 top-0 h-full w-full sm:max-w-md bg-white shadow-2xl z-50 flex flex-col"
+      class="cart cart-hidden fixed right-0 top-0 h-full w-full sm:max-w-md bg-white shadow-2xl flex flex-col"
     >
       <!-- Cart will be rendered here by JS -->
     </div>

--- a/contact.html
+++ b/contact.html
@@ -382,6 +382,19 @@
       </div>
     </footer>
 
+    <!-- Floating Cart Button -->
+    <button
+      id="floating-cart-btn"
+      class="floating-cart-btn fixed bottom-6 right-6 bg-forest-green text-white w-16 h-16 rounded-full shadow-lg flex items-center justify-center z-40 touch-target hover:bg-forest-green-dark transition transform hover:scale-110"
+    >
+      <i data-lucide="shopping-bag" class="w-7 h-7"></i>
+      <span
+        id="cart-item-count"
+        class="absolute -top-2 -right-2 bg-pink-500 text-white text-xs rounded-full h-6 w-6 flex items-center justify-center font-bold"
+        >0</span
+      >
+    </button>
+
     <!-- Cart Backdrop -->
     <div
       id="cart-backdrop"

--- a/index.html
+++ b/index.html
@@ -621,7 +621,7 @@
     <!-- Shopping Cart -->
     <div
       id="cart"
-      class="cart cart-hidden fixed right-0 top-0 h-full w-full sm:max-w-md bg-white shadow-2xl z-50 flex flex-col"
+      class="cart cart-hidden fixed right-0 top-0 h-full w-full sm:max-w-md bg-white shadow-2xl flex flex-col"
     >
       <!-- Cart will be rendered here by JS -->
     </div>

--- a/menu.html
+++ b/menu.html
@@ -311,7 +311,7 @@
     <!-- Shopping Cart -->
     <div
       id="cart"
-      class="cart cart-hidden fixed right-0 top-0 h-full w-full sm:max-w-md bg-white shadow-2xl z-50 flex flex-col"
+      class="cart cart-hidden fixed right-0 top-0 h-full w-full sm:max-w-md bg-white shadow-2xl flex flex-col"
     >
       <!-- Cart will be rendered here by JS -->
     </div>

--- a/script.js
+++ b/script.js
@@ -35,6 +35,14 @@ function openCart() {
     backdrop.classList.add("visible");
   }
   document.body.style.overflow = "hidden";
+
+  // Focus on cart for accessibility
+  setTimeout(() => {
+    const closeButton = cartElement.querySelector("#close-cart");
+    if (closeButton) {
+      closeButton.focus();
+    }
+  }, 100);
 }
 
 function closeCart() {

--- a/script.js
+++ b/script.js
@@ -581,8 +581,10 @@ function showCheckoutModal() {
   `;
 
   const actions = `
-    <button type="button" class="modal-close-btn bg-gray-500 text-white font-semibold py-3 px-6 rounded-full touch-target hover:bg-gray-600 transition">Cancel</button>
-    <button type="button" id="confirm-order-btn" class="bg-amber-700 text-white font-semibold py-3 px-6 rounded-full touch-target hover:bg-amber-800 transition">Confirm Order</button>
+    <div class="flex justify-end gap-3">
+      <button type="button" class="modal-close-btn bg-gray-500 text-white font-semibold py-3 px-6 rounded-full touch-target hover:bg-gray-600 transition">Cancel</button>
+      <button type="button" id="confirm-order-btn" class="bg-amber-700 text-white font-semibold py-3 px-6 rounded-full touch-target hover:bg-amber-800 transition">Confirm Order</button>
+    </div>
   `;
 
   showModal("Checkout", modalBody, actions);
@@ -707,8 +709,10 @@ document.addEventListener("DOMContentLoaded", function () {
         }
 
         modalBody += "</div>";
-        const actions = `<button class="modal-close-btn bg-gray-500 text-white font-bold py-2 px-6 rounded-full touch-target">Cancel</button>
-                                   <button id="save-customizations-btn" data-item-id="${item.id}" class="bg-amber-800 text-white font-bold py-2 px-6 rounded-full touch-target">Add to Cart</button>`;
+        const actions = `<div class="flex justify-end gap-3">
+                                   <button class="modal-close-btn bg-gray-500 text-white font-bold py-2 px-6 rounded-full touch-target hover:bg-gray-600 transition">Cancel</button>
+                                   <button id="save-customizations-btn" data-item-id="${item.id}" class="bg-amber-800 text-white font-bold py-2 px-6 rounded-full touch-target hover:bg-amber-900 transition">Add to Cart</button>
+                                 </div>`;
         showModal(`Customize ${item.name}`, modalBody, actions);
       } else if (button.classList.contains("allergens-btn")) {
         const itemId = parseInt(button.dataset.itemId);

--- a/script.js
+++ b/script.js
@@ -455,7 +455,7 @@ function updateFloatingCartButton() {
   }
 
   // Update header cart count
-  const headerCartCount = document.getElementById("cart-item-count");
+  const headerCartCount = document.getElementById("header-cart-count");
   if (headerCartCount) {
     headerCartCount.textContent = totalItems;
   }

--- a/script.js
+++ b/script.js
@@ -513,89 +513,14 @@ function updateCartItemQuantity(uniqueId, action) {
   }
 }
 
-function showCheckoutModal() {
+function goToCheckout() {
   if (cartItems.length === 0) return;
 
-  const subtotal = cartItems.reduce(
-    (sum, item) => sum + item.price * item.quantity,
-    0,
-  );
-  const tax = subtotal * 0.06625;
-  const total = subtotal + tax;
+  // Save cart items to localStorage for checkout page
+  localStorage.setItem("cartItems", JSON.stringify(cartItems));
 
-  const modalBody = `
-    <div class="space-y-4 text-left">
-      <div class="bg-gray-50 p-4 rounded-lg">
-        <h4 class="font-semibold mb-3">Order Summary</h4>
-        <div class="space-y-2 text-sm">
-          ${cartItems
-            .map(
-              (item) => `
-            <div class="flex justify-between">
-              <span>${item.name} x${item.quantity}</span>
-              <span>$${(item.price * item.quantity).toFixed(2)}</span>
-            </div>
-          `,
-            )
-            .join("")}
-          <hr class="my-2">
-          <div class="flex justify-between">
-            <span>Subtotal:</span>
-            <span>$${subtotal.toFixed(2)}</span>
-          </div>
-          <div class="flex justify-between">
-            <span>Tax:</span>
-            <span>$${tax.toFixed(2)}</span>
-          </div>
-          <div class="flex justify-between font-bold">
-            <span>Total:</span>
-            <span>$${total.toFixed(2)}</span>
-          </div>
-        </div>
-      </div>
-
-      <form id="checkout-form" class="space-y-4">
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Name *</label>
-          <input type="text" name="name" required class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:border-amber-700 focus:ring-1 focus:ring-amber-700">
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Phone *</label>
-          <input type="tel" name="phone" required class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:border-amber-700 focus:ring-1 focus:ring-amber-700">
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
-          <input type="email" name="email" class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:border-amber-700 focus:ring-1 focus:ring-amber-700">
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Pickup Time</label>
-          <select name="pickupTime" class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:border-amber-700 focus:ring-1 focus:ring-amber-700">
-            <option value="asap">As soon as possible (15-20 min)</option>
-            <option value="30min">30 minutes</option>
-            <option value="1hour">1 hour</option>
-            <option value="2hours">2 hours</option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Special Instructions</label>
-          <textarea name="instructions" rows="3" class="w-full border border-gray-300 rounded-lg px-3 py-2 focus:border-amber-700 focus:ring-1 focus:ring-amber-700" placeholder="Any special requests or dietary considerations..."></textarea>
-        </div>
-      </form>
-
-      <div class="bg-blue-50 p-3 rounded-lg text-sm text-blue-800">
-        <strong>Pickup Only:</strong> Please pay in-store when you arrive. We accept cash, card, and contactless payments.
-      </div>
-    </div>
-  `;
-
-  const actions = `
-    <div class="flex justify-end gap-3">
-      <button type="button" class="modal-close-btn bg-gray-500 text-white font-semibold py-3 px-6 rounded-full touch-target hover:bg-gray-600 transition">Cancel</button>
-      <button type="button" id="confirm-order-btn" class="bg-amber-700 text-white font-semibold py-3 px-6 rounded-full touch-target hover:bg-amber-800 transition">Confirm Order</button>
-    </div>
-  `;
-
-  showModal("Checkout", modalBody, actions);
+  // Redirect to checkout page
+  window.location.href = "checkout.html";
 }
 
 function showModal(title, body, actions) {
@@ -651,7 +576,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Checkout button
     if (button.id === "checkout-btn") {
-      showCheckoutModal();
+      goToCheckout();
       return;
     }
 
@@ -673,53 +598,6 @@ document.addEventListener("DOMContentLoaded", function () {
     // Modal buttons
     if (button.classList.contains("modal-close-btn")) {
       hideModal();
-      return;
-    }
-
-    if (button.id === "confirm-order-btn") {
-      const form = document.getElementById("checkout-form");
-      if (form && form.checkValidity()) {
-        const formData = new FormData(form);
-        const orderData = {
-          name: formData.get("name"),
-          phone: formData.get("phone"),
-          email: formData.get("email"),
-          pickupTime: formData.get("pickupTime"),
-          instructions: formData.get("instructions"),
-          items: cartItems,
-          timestamp: new Date().toLocaleString(),
-        };
-
-        console.log("Order submitted:", orderData);
-
-        // Clear cart
-        cartItems = [];
-        renderCart();
-        updateCartCounts();
-
-        // Show confirmation
-        hideModal();
-        showModal(
-          "Order Confirmed!",
-          `<div class="text-center">
-            <div class="text-green-600 mb-4">
-              <i data-lucide="check-circle" class="w-16 h-16 mx-auto mb-2"></i>
-            </div>
-            <p class="mb-4">Thank you <strong>${orderData.name}</strong>! Your order has been received.</p>
-            <p class="text-sm text-gray-600 mb-4">We'll call you at <strong>${orderData.phone}</strong> when your order is ready for pickup.</p>
-            <div class="bg-amber-50 p-3 rounded-lg text-sm">
-              <strong>Estimated pickup time:</strong> ${orderData.pickupTime === "asap" ? "15-20 minutes" : orderData.pickupTime}
-            </div>
-          </div>`,
-          '<div class="flex justify-center"><button class="modal-close-btn bg-amber-700 text-white font-semibold py-3 px-8 rounded-full touch-target hover:bg-amber-800 transition">OK</button></div>',
-        );
-
-        if (typeof lucide !== "undefined") {
-          lucide.createIcons();
-        }
-      } else {
-        form.reportValidity();
-      }
       return;
     }
 

--- a/script.js
+++ b/script.js
@@ -724,7 +724,7 @@ document.addEventListener("DOMContentLoaded", function () {
         showModal(
           `${item.name} - Allergen Information`,
           `<p class="text-gray-700"><strong>Contains:</strong> ${allergensList}</p>`,
-          '<button class="modal-close-btn bg-amber-800 text-white font-bold py-2 px-8 rounded-full touch-target">OK</button>',
+          '<div class="flex justify-center"><button class="modal-close-btn bg-amber-800 text-white font-bold py-2 px-8 rounded-full touch-target hover:bg-amber-900 transition">OK</button></div>',
         );
       }
     });
@@ -845,8 +845,8 @@ document.addEventListener("DOMContentLoaded", function () {
               <div class="bg-amber-50 p-3 rounded-lg text-sm">
                 <strong>Estimated pickup time:</strong> ${orderData.pickupTime === "asap" ? "15-20 minutes" : orderData.pickupTime}
               </div>
-            </div>`,
-            '<button class="modal-close-btn bg-amber-700 text-white font-semibold py-3 px-8 rounded-full touch-target hover:bg-amber-800 transition">OK</button>',
+            '</div>`,
+            '<div class="flex justify-center"><button class="modal-close-btn bg-amber-700 text-white font-semibold py-3 px-8 rounded-full touch-target hover:bg-amber-800 transition">OK</button></div>',
           );
 
           // Re-create icons for the new modal content
@@ -868,7 +868,7 @@ document.addEventListener("DOMContentLoaded", function () {
       showModal(
         "Thank You!",
         "Your catering inquiry has been submitted. We'll be in touch with you soon!",
-        '<button class="modal-close-btn bg-amber-700 text-white font-semibold py-3 px-8 rounded-full touch-target hover:bg-amber-800 transition">OK</button>',
+        '<div class="flex justify-center"><button class="modal-close-btn bg-amber-700 text-white font-semibold py-3 px-8 rounded-full touch-target hover:bg-amber-800 transition">OK</button></div>',
       );
       e.target.reset();
     });

--- a/script.js
+++ b/script.js
@@ -878,6 +878,17 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
+  // Escape key to close cart
+  document.addEventListener("keydown", (e) => {
+    if (
+      e.key === "Escape" &&
+      cartElement &&
+      !cartElement.classList.contains("cart-hidden")
+    ) {
+      closeCart();
+    }
+  });
+
   // Initialize the application
   console.log("Initializing application...", {
     featuredGrid,

--- a/script.js
+++ b/script.js
@@ -350,41 +350,47 @@ function renderCart() {
         .map(
           (item) => `
         <div class="cart-item-card mb-4 p-4 border rounded-lg bg-white">
-          <div class="flex justify-between items-start mb-2">
-            <h4 class="font-semibold text-gray-900">${item.name}</h4>
-            <button class="remove-item-btn text-red-500 hover:text-red-700 p-1" data-unique-id="${item.uniqueId}">
-              <i data-lucide="trash-2" class="w-4 h-4"></i>
-            </button>
-          </div>
-          <p class="text-sm text-gray-600 mb-2">${item.description}</p>
-          ${
-            item.customizations && Object.keys(item.customizations).length > 0
-              ? `
-            <div class="text-xs text-gray-500 mb-2">
-              ${Object.entries(item.customizations)
-                .map(([key, value]) => {
-                  if (
-                    key === "toppings" &&
-                    Array.isArray(value) &&
-                    value.length > 0
-                  ) {
-                    return `Toppings: ${value.join(", ")}`;
-                  } else if (key === "test" && value) {
-                    return `Test: ${value}`;
-                  }
-                  return "";
-                })
-                .filter(Boolean)
-                .join(" • ")}
+          <div class="flex gap-3 mb-3">
+            <img src="${item.img}" alt="${item.name}" class="cart-item-image w-16 h-16 object-cover rounded-lg flex-shrink-0">
+            <div class="flex-1 min-w-0">
+              <div class="flex justify-between items-start mb-1">
+                <h4 class="font-semibold text-gray-900 text-sm leading-tight">${item.name}</h4>
+                <button class="remove-item-btn text-red-500 hover:text-red-700 p-1 flex-shrink-0" data-unique-id="${item.uniqueId}">
+                  <i data-lucide="trash-2" class="w-4 h-4"></i>
+                </button>
+              </div>
+              <p class="text-xs text-gray-600 mb-2 line-clamp-2">${item.description}</p>
+              ${
+                item.customizations &&
+                Object.keys(item.customizations).length > 0
+                  ? `
+                <div class="text-xs text-gray-500 mb-2">
+                  ${Object.entries(item.customizations)
+                    .map(([key, value]) => {
+                      if (
+                        key === "toppings" &&
+                        Array.isArray(value) &&
+                        value.length > 0
+                      ) {
+                        return `Toppings: ${value.join(", ")}`;
+                      } else if (key === "test" && value) {
+                        return `Test: ${value}`;
+                      }
+                      return "";
+                    })
+                    .filter(Boolean)
+                    .join(" • ")}
+                </div>
+              `
+                  : ""
+              }
             </div>
-          `
-              : ""
-          }
+          </div>
           <div class="flex justify-between items-center">
             <div class="flex items-center gap-2">
-              <button class="quantity-btn-cart bg-red-500 text-white w-8 h-8 rounded-full flex items-center justify-center hover:bg-red-600" data-unique-id="${item.uniqueId}" data-change="-1">−</button>
+              <button class="quantity-btn-cart bg-red-500 text-white w-8 h-8 rounded-full flex items-center justify-center hover:bg-red-600 transition" data-unique-id="${item.uniqueId}" data-change="-1">−</button>
               <span class="font-semibold w-8 text-center">${item.quantity}</span>
-              <button class="quantity-btn-cart bg-green-500 text-white w-8 h-8 rounded-full flex items-center justify-center hover:bg-green-600" data-unique-id="${item.uniqueId}" data-change="1">+</button>
+              <button class="quantity-btn-cart bg-green-500 text-white w-8 h-8 rounded-full flex items-center justify-center hover:bg-green-600 transition" data-unique-id="${item.uniqueId}" data-change="1">+</button>
             </div>
             <p class="text-amber-700 font-bold">$${(item.price * item.quantity).toFixed(2)}</p>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -410,6 +410,24 @@ body {
   font-size: 1.1em;
 }
 
+/* Cart Item Image */
+.cart-item-image {
+  border: 1px solid rgb(229, 231, 235);
+  transition: transform 0.2s ease;
+}
+
+.cart-item-image:hover {
+  transform: scale(1.05);
+}
+
+/* Text truncation for cart descriptions */
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* Cart Scrolling */
 .cart-items-container {
   flex: 1;

--- a/styles.css
+++ b/styles.css
@@ -251,11 +251,12 @@ body {
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: transparent;
+  background: rgba(0, 0, 0, 0.5);
   z-index: 9998;
   opacity: 0;
   visibility: hidden;
   transition: all 0.3s ease;
+  backdrop-filter: blur(2px);
 }
 
 .cart-backdrop.visible {

--- a/styles.css
+++ b/styles.css
@@ -597,6 +597,16 @@ select:focus {
     max-width: 100% !important;
   }
 
+  .cart-item-card {
+    padding: 12px;
+    margin-bottom: 12px;
+  }
+
+  .cart-item-image {
+    width: 14;
+    height: 14;
+  }
+
   .filter-btn {
     font-size: 14px;
     padding: 10px 16px;

--- a/styles.css
+++ b/styles.css
@@ -285,6 +285,7 @@ body {
   transform: scale(0);
   opacity: 0;
   box-shadow: 0 8px 24px rgba(6, 95, 70, 0.3);
+  z-index: 1000;
 }
 
 .floating-cart-btn.visible {

--- a/styles.css
+++ b/styles.css
@@ -235,7 +235,7 @@ body {
   transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
   background: white;
   box-shadow: -8px 0 32px rgba(17, 24, 39, 0.2);
-  z-index: 9999;
+  z-index: 10000;
   max-height: 100vh;
   overflow: hidden;
 }


### PR DESCRIPTION
This commit adds a new checkout page (checkout.html) with comprehensive order functionality and updates the existing styles.

**New checkout.html features:**
- Complete checkout page with header navigation and mobile menu
- Order summary section with cart items display
- Tipping functionality with preset percentages (15%, 18%, 23%) and custom option
- Order totals calculation including subtotal, tax (6.625%), tip, and final total
- Customer information form for pickup details
- Responsive design with grid layout for desktop and mobile

**CSS updates in styles.css:**
- Increased cart z-index from 9999 to 10000 for proper layering
- Enhanced cart backdrop with semi-transparent background (rgba(0, 0, 0, 0.5)) and blur effect
- Added cart item image styling with hover effects and border
- Implemented text truncation utility (.line-clamp-2) for cart descriptions
- Added mobile-specific cart item styling with adjusted padding and image sizes
- Set floating cart button z-index to 1000

The checkout page integrates with the existing cart system and maintains the site's design consistency with Tailwind CSS classes and custom styling.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ddaae267e62748f78b802d9e8c761c9d/nova-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddaae267e62748f78b802d9e8c761c9d</projectId>-->
<!--<branchName>nova-haven</branchName>-->